### PR TITLE
Ensure all tests are retained when evaluating empty patch (fixes #128)

### DIFF
--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -127,9 +127,9 @@ class Evaluator(object):
         line_coverage_by_test = self.__problem.coverage
         lines_changed = candidate.lines_changed(self.__problem)
 
-		# if no lines are changed, retain all tests (fixes issue #128)
-		if not lines_changed:
-		    return (tests, set())
+        # if no lines are changed, retain all tests (fixes issue #128)
+        if not lines_changed:
+            return (tests, set())
 
         keep = []  # type: List[Test]
         drop = set()  # type: Set[Test]

--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -130,7 +130,7 @@ class Evaluator(object):
         drop = set()  # type: Set[Test]
         for test in tests:
             test_line_coverage = line_coverage_by_test[test.name]
-            if not any(line in test_line_coverage for line in lines_changed):
+            if len(lines_changed)>0 and not any(line in test_line_coverage for line in lines_changed):
                 drop.add(test)
             else:
                 keep.append(test)

--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -126,11 +126,16 @@ class Evaluator(object):
                                 ) -> Tuple[List[Test], Set[Test]]:
         line_coverage_by_test = self.__problem.coverage
         lines_changed = candidate.lines_changed(self.__problem)
+
+		# if no lines are changed, retain all tests (fixes issue #128)
+		if not lines_changed:
+		    return (tests, set())
+
         keep = []  # type: List[Test]
         drop = set()  # type: Set[Test]
         for test in tests:
             test_line_coverage = line_coverage_by_test[test.name]
-            if len(lines_changed)>0 and not any(line in test_line_coverage for line in lines_changed):
+            if not any(line in test_line_coverage for line in lines_changed):
                 drop.add(test)
             else:
                 keep.append(test)


### PR DESCRIPTION
GA returning empty set as plausible repair [type: genetic] #128
-- ensures that if the lines_changed is empty, that no tests are dropped

Potential solution identified from debug outlined in [gitq conversation](https://gitq.com/squaresLab/Darjeeling/topics/7/ga-returning-empty-set-as-plausible-repair)