### PR TITLE
Added dynamic plugin via Flask-style naming conventions

### DIFF
--- a/src/darjeeling/__init__.py
+++ b/src/darjeeling/__init__.py
@@ -7,15 +7,16 @@ from . import exceptions
 from .version import __version__
 from .problem import Problem
 
-_logging.getLogger(__name__).setLevel(_logging.INFO)
-_logging.getLogger(__name__).addHandler(_logging.NullHandler())
+_logger = _logging.getLogger(__name__)
+_logger.setLevel(_logging.INFO)
+_logger.addHandler(_logging.NullHandler())
 
 
 def _load_plugins() -> None:
     """Dynamically loads all plugins for Darjeeling."""
     for finder, name, is_pkg in _pkgutil.iter_modules():
         if name.startswith('darjeeling_'):
-            logger.info("loading plugin: %s", name)
+            _logger.info("loading plugin: %s", name)
             _importlib.import_module(name)
 
 

--- a/src/darjeeling/__init__.py
+++ b/src/darjeeling/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging as _logging
 import importlib as _importlib
 import pkgutil as _pkgutil

--- a/src/darjeeling/__init__.py
+++ b/src/darjeeling/__init__.py
@@ -10,4 +10,12 @@ from .problem import Problem
 _logging.getLogger(__name__).setLevel(_logging.INFO)
 _logging.getLogger(__name__).addHandler(_logging.NullHandler())
 
-# TODO dynamically load plugins
+
+def _load_plugins() -> None:
+    """Dynamically loads all plugins for Darjeeling."""
+    for finder, name, is_pkg in _pkgutil.iter_modules():
+        if name.startswith('darjeeling_'):
+            _importlib.import_module(name)
+
+
+_load_plugins()

--- a/src/darjeeling/__init__.py
+++ b/src/darjeeling/__init__.py
@@ -1,8 +1,12 @@
-import logging
+import logging as _logging
+import importlib as _importlib
+import pkgutil as _pkgutil
 
 from . import exceptions
 from .version import __version__
 from .problem import Problem
 
-logging.getLogger(__name__).setLevel(logging.INFO)
-logging.getLogger(__name__).addHandler(logging.NullHandler())
+_logging.getLogger(__name__).setLevel(_logging.INFO)
+_logging.getLogger(__name__).addHandler(_logging.NullHandler())
+
+# TODO dynamically load plugins

--- a/src/darjeeling/__init__.py
+++ b/src/darjeeling/__init__.py
@@ -15,6 +15,7 @@ def _load_plugins() -> None:
     """Dynamically loads all plugins for Darjeeling."""
     for finder, name, is_pkg in _pkgutil.iter_modules():
         if name.startswith('darjeeling_'):
+            logger.info("loading plugin: %s", name)
             _importlib.import_module(name)
 
 


### PR DESCRIPTION
All modules that begin with the name `darjeeling_` will be automatically imported by Darjeeling at run-time.

See: https://packaging.python.org/guides/creating-and-discovering-plugins/#using-naming-convention