### PR TITLE
Clear contents of patch directory rather than destroying directory

### DIFF
--- a/src/darjeeling/searcher/exhaustive.py
+++ b/src/darjeeling/searcher/exhaustive.py
@@ -32,7 +32,7 @@ class ExhaustiveSearcherConfig(SearcherConfig):
         return ExhaustiveSearcherConfig()
 
 
-class ExhaustiveSearcher(Searcher[ExhaustiveSearcherConfig]):
+class ExhaustiveSearcher(Searcher):
     CONFIG = ExhaustiveSearcherConfig
 
     @classmethod

--- a/src/darjeeling/searcher/genetic.py
+++ b/src/darjeeling/searcher/genetic.py
@@ -55,7 +55,7 @@ class GeneticSearcherConfig(SearcherConfig):
                                      sample_size=sample_size)
 
 
-class GeneticSearcher(Searcher[GeneticSearcherConfig]):
+class GeneticSearcher(Searcher):
     CONFIG = GeneticSearcherConfig
 
     @classmethod

--- a/src/darjeeling/session.py
+++ b/src/darjeeling/session.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import List, Dict, Any, Type, Optional, Iterator
+import glob
 import os
 import sys
 import asyncio

--- a/src/darjeeling/session.py
+++ b/src/darjeeling/session.py
@@ -51,8 +51,10 @@ class Session:
         # create the patch directory
         dir_patches = os.path.abspath('patches')
         if os.path.exists(dir_patches):
-            logger.warning("destroying existing patch directory")
-            shutil.rmtree(dir_patches)
+            logger.warning("clearing existing patch directory")
+            for fn in glob.glob(f'{dir_patches}/**'):
+                if os.path.isfile(fn):
+                    os.remove(fn)
 
         # seed the RNG
         # FIXME use separate RNG for each session


### PR DESCRIPTION
Allows patch directory to be volume mounted when Darjeeling is used with Docker.