### PR TITLE
Concretes line transformation classes

### DIFF
--- a/example/gcd/Makefile
+++ b/example/gcd/Makefile
@@ -1,7 +1,7 @@
 all: docker
 
 docker:
-	docker build -t squareslab/tse2012:gcd docker
+	docker build -t darjeeling/example:gcd docker
 
 check: docker
 	darjeeling repair repair.yml

--- a/example/gcd/repair.yml
+++ b/example/gcd/repair.yml
@@ -1,7 +1,7 @@
 version: '1.0'
 
 program:
-  image: squareslab/tse2012:gcd
+  image: darjeeling/example:gcd
   language: c
   source-directory: /experiment/source
   build-instructions:

--- a/src/darjeeling/config.py
+++ b/src/darjeeling/config.py
@@ -207,10 +207,10 @@ class Config:
         elif threads is None:
             threads = 1
 
-        if 'run_redundant_tests' in yml:
-            if not isinstance(yml['run_redundant_tests'], bool):
-                err("'threads' property should be an bool")
-            run_redundant_tests = yml['run_redundant_tests']
+        if 'run-redundant-tests' in yml:
+            if not isinstance(yml['run-redundant-tests'], bool):
+                err("'run-redundant-tests' property should be an bool")
+            run_redundant_tests = yml['run-redundant-tests']
 
         # no seed override; seed provided in config
         if seed is None and 'seed' in yml:

--- a/src/darjeeling/config.py
+++ b/src/darjeeling/config.py
@@ -172,7 +172,7 @@ class Config:
                  terminate_early: bool = True,
                  seed: Optional[int] = None,
                  threads: Optional[int] = None,
-                 run_redundant_tests: Optional[bool] = False,
+                 run_redundant_tests: bool = False,
                  limit_candidates: Optional[int] = None,
                  limit_time_minutes: Optional[int] = None,
                  dir_patches: Optional[str] = None

--- a/src/darjeeling/config.py
+++ b/src/darjeeling/config.py
@@ -118,6 +118,10 @@ class Config:
         discovering an acceptable patch.
     threads: int
         The number of threads over which the search should be distributed.
+    run_redundant_tests: bool
+        Specifies if redundant tests should be run. Tests are deemed 
+        redundant if a candidate patch does not change lines that the
+        test uses. Lines used are determined by test coverage.
     resource_limits: ResourceLimits
         Limits on the resources that may be consumed during the search.
     limit_time_minutes: int, optional
@@ -141,6 +145,7 @@ class Config:
     optimizations: OptimizationsConfig = attr.ib(factory=OptimizationsConfig)
     terminate_early: bool = attr.ib(default=True)
     threads: int = attr.ib(default=1)
+    run_redundant_tests: bool = attr.ib(default=False)
 
     @seed.validator
     def validate_seed(self, attribute, value):
@@ -167,6 +172,7 @@ class Config:
                  terminate_early: bool = True,
                  seed: Optional[int] = None,
                  threads: Optional[int] = None,
+                 run_redundant_tests: Optional[bool] = False,
                  limit_candidates: Optional[int] = None,
                  limit_time_minutes: Optional[int] = None,
                  dir_patches: Optional[str] = None
@@ -200,6 +206,11 @@ class Config:
             threads = yml['threads']
         elif threads is None:
             threads = 1
+
+        if 'run_redundant_tests' in yml:
+            if not isinstance(yml['run_redundant_tests'], bool):
+                err("'threads' property should be an bool")
+            run_redundant_tests = yml['run_redundant_tests']
 
         # no seed override; seed provided in config
         if seed is None and 'seed' in yml:
@@ -251,6 +262,7 @@ class Config:
 
         return Config(seed=seed,
                       threads=threads,
+                      run_redundant_tests=run_redundant_tests,
                       terminate_early=terminate_early,
                       resource_limits=resource_limits,
                       transformations=transformations,

--- a/src/darjeeling/config.py
+++ b/src/darjeeling/config.py
@@ -119,7 +119,7 @@ class Config:
     threads: int
         The number of threads over which the search should be distributed.
     run_redundant_tests: bool
-        Specifies if redundant tests should be run. Tests are deemed 
+        Specifies if redundant tests should be run. Tests are deemed
         redundant if a candidate patch does not change lines that the
         test uses. Lines used are determined by test coverage.
     resource_limits: ResourceLimits

--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -47,7 +47,8 @@ class Evaluator(DarjeelingEventProducer):
                  num_workers: int = 1,
                  terminate_early: bool = True,
                  sample_size: Optional[Union[float, int]] = None,
-                 outcomes: Optional[CandidateOutcomeStore] = None
+                 outcomes: Optional[CandidateOutcomeStore] = None,
+                 run_redundant_tests: bool = False
                  ) -> None:
         super().__init__()
         self.__problem = problem
@@ -59,6 +60,7 @@ class Evaluator(DarjeelingEventProducer):
         self.__num_workers = num_workers
         self.__terminate_early = terminate_early
         self.__outcomes = outcomes or CandidateOutcomeStore()
+        self.__run_redundant_tests = run_redundant_tests
 
         self.__tests_failing: FrozenSet[Test] = \
             frozenset(self.__problem.failing_tests)
@@ -173,7 +175,10 @@ class Evaluator(DarjeelingEventProducer):
 
         # select a subset of tests to use for this evaluation
         tests, remainder = self._select_tests()
-        tests, redundant = self._filter_redundant_tests(candidate, tests)
+        if not self.__run_redundant_tests:
+            tests, redundant = self._filter_redundant_tests(candidate, tests)
+        else:
+            redundant = set()
 
         # compute outcomes for redundant tests
         test_outcomes = TestOutcomeSet({

--- a/src/darjeeling/searcher/base.py
+++ b/src/darjeeling/searcher/base.py
@@ -27,7 +27,8 @@ class Searcher(DarjeelingEventProducer, abc.ABC):
                  *,
                  threads: int = 1,
                  terminate_early: bool = True,
-                 test_sample_size: Optional[Union[int, float]] = None
+                 test_sample_size: Optional[Union[int, float]] = None,
+                 run_redundant_tests: bool = True
                  ) -> None:
         """Constructs a new searcher.
 
@@ -40,6 +41,10 @@ class Searcher(DarjeelingEventProducer, abc.ABC):
         threads: int
             the number of threads that should be made available to
             the search process.
+        run_redundant_tests: bool
+            Specifies if redundant tests should be run. Tests are deemed 
+            redundant if a candidate patch does not change lines that the
+            test uses. Lines used are determined by test coverage.
         """
         logger.debug("constructing searcher")
         super().__init__()
@@ -50,7 +55,8 @@ class Searcher(DarjeelingEventProducer, abc.ABC):
                                      resources=resources,
                                      num_workers=threads,
                                      terminate_early=terminate_early,
-                                     sample_size=test_sample_size)
+                                     sample_size=test_sample_size,
+                                     run_redundant_tests=run_redundant_tests)
 
         self.__started = False
         self.__stopped = False

--- a/src/darjeeling/searcher/base.py
+++ b/src/darjeeling/searcher/base.py
@@ -42,7 +42,7 @@ class Searcher(DarjeelingEventProducer, abc.ABC):
             the number of threads that should be made available to
             the search process.
         run_redundant_tests: bool
-            Specifies if redundant tests should be run. Tests are deemed 
+            Specifies if redundant tests should be run. Tests are deemed
             redundant if a candidate patch does not change lines that the
             test uses. Lines used are determined by test coverage.
         """

--- a/src/darjeeling/searcher/config.py
+++ b/src/darjeeling/searcher/config.py
@@ -48,5 +48,6 @@ class SearcherConfig(abc.ABC):
               localization: 'Localization',
               *,
               threads: int = 1,
+              run_redundant_tests: bool = False
               ) -> 'Searcher':
         ...

--- a/src/darjeeling/searcher/exhaustive.py
+++ b/src/darjeeling/searcher/exhaustive.py
@@ -42,12 +42,14 @@ class ExhaustiveSearcherConfig(SearcherConfig):
               transformations: 'ProgramTransformations',
               localization: 'Localization',
               *,
-              threads: int = 1
+              threads: int = 1,
+              run_redundant_tests: bool = False
               ) -> Searcher:
         return ExhaustiveSearcher(problem=problem,
                                   resources=resources,
                                   transformations=transformations,
-                                  threads=threads)
+                                  threads=threads,
+                                  run_redundant_tests=run_redundant_tests)
 
 
 class ExhaustiveSearcher(Searcher):
@@ -56,13 +58,15 @@ class ExhaustiveSearcher(Searcher):
                  resources: ResourceUsageTracker,
                  transformations: 'ProgramTransformations',
                  *,
-                 threads: int = 1
+                 threads: int = 1,
+                 run_redundant_tests: bool = False
                  ) -> None:
         # FIXME for now!
         self.__candidates = self.all_single_edit_patches(problem, transformations)
         super().__init__(problem=problem,
                          resources=resources,
-                         threads=threads)
+                         threads=threads,
+                         run_redundant_tests=run_redundant_tests)
 
     @staticmethod
     def all_single_edit_patches(problem: 'Problem',

--- a/src/darjeeling/searcher/genetic.py
+++ b/src/darjeeling/searcher/genetic.py
@@ -58,7 +58,8 @@ class GeneticSearcherConfig(SearcherConfig):
               transformations: ProgramTransformations,
               localization: 'Localization',
               *,
-              threads: int = 1
+              threads: int = 1,
+              run_redundant_tests: bool = False
               ) -> Searcher:
         return GeneticSearcher(problem=problem,
                                resources=resources,
@@ -69,7 +70,8 @@ class GeneticSearcherConfig(SearcherConfig):
                                rate_crossover=self.rate_crossover,
                                rate_mutation=self.rate_mutation,
                                tournament_size=self.tournament_size,
-                               test_sample_size=self.sample_size)
+                               test_sample_size=self.sample_size,
+                                  run_redundant_tests=run_redundant_tests)
 
 
 class GeneticSearcher(Searcher):
@@ -84,6 +86,7 @@ class GeneticSearcher(Searcher):
                  rate_mutation: float = 1.0,
                  tournament_size: int = 2,
                  threads: int = 1,
+                 run_redundant_tests: bool = True,
                  test_sample_size: Optional[Union[int, float]] = None
                  ) -> None:
         self.__population_size = population_size
@@ -103,6 +106,7 @@ class GeneticSearcher(Searcher):
         super().__init__(problem=problem,
                          resources=resources,
                          threads=threads,
+                         run_redundant_tests=run_redundant_tests,
                          test_sample_size=test_sample_size,
                          terminate_early=False)
 

--- a/src/darjeeling/searcher/genetic.py
+++ b/src/darjeeling/searcher/genetic.py
@@ -71,7 +71,7 @@ class GeneticSearcherConfig(SearcherConfig):
                                rate_mutation=self.rate_mutation,
                                tournament_size=self.tournament_size,
                                test_sample_size=self.sample_size,
-                                  run_redundant_tests=run_redundant_tests)
+                               run_redundant_tests=run_redundant_tests)
 
 
 class GeneticSearcher(Searcher):

--- a/src/darjeeling/session.py
+++ b/src/darjeeling/session.py
@@ -64,6 +64,7 @@ class Session(DarjeelingEventProducer):
         logger.info(f"using language: {cfg.program.language.value}")
         logger.info(f"using optimizations: {cfg.optimizations}")
         logger.info(f"using coverage config: {cfg.coverage}")
+        logger.info(f"running redundant tests? {cfg.run_redundant_tests}")
         logger.info(f"using random number generator seed: {cfg.seed}")
 
         if not cfg.terminate_early:
@@ -133,7 +134,8 @@ class Session(DarjeelingEventProducer):
                                     resources=resources,
                                     transformations=transformations,
                                     localization=localization,
-                                    threads=cfg.threads)
+                                    threads=cfg.threads,
+                                    run_redundant_tests=cfg.run_redundant_tests)
 
         # build session
         return Session(dir_patches=dir_patches,

--- a/src/darjeeling/transformation/base.py
+++ b/src/darjeeling/transformation/base.py
@@ -22,12 +22,6 @@ class Transformation(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def line(self) -> FileLine:
-        """The line at which this transformation is applied."""
-        ...
-
-    @property
-    @abc.abstractmethod
     def schema(self) -> 'TransformationSchema':
         """The schema that was used to produce this transformation."""
         ...

--- a/src/darjeeling/transformation/line.py
+++ b/src/darjeeling/transformation/line.py
@@ -21,8 +21,11 @@ if typing.TYPE_CHECKING:
     from ..problem import Problem
 
 
+@attr.s(frozen=True, auto_attribs=True)
 class LineTransformation(Transformation):
     """Base class for all line-based transformations."""
+    _schema: 'LineTransformationSchema'
+    line: FileLine
 
 
 @attr.s(frozen=True, auto_attribs=True)
@@ -63,9 +66,6 @@ class LineTransformationSchema(TransformationSchema[LineTransformation]):
 
 @attr.s(frozen=True, auto_attribs=True)
 class DeleteLine(LineTransformation):
-    _schema: LineTransformationSchema
-    line: FileLine
-
     def to_replacement(self) -> Replacement:
         sources = self._schema._problem.sources
         loc = sources.line_to_location_range(self.line)
@@ -99,8 +99,6 @@ class DeleteLine(LineTransformation):
 
 @attr.s(frozen=True, auto_attribs=True)
 class ReplaceLine(LineTransformation):
-    _schema: LineTransformationSchema
-    line: FileLine
     replacement: FileLine
 
     @property
@@ -140,8 +138,6 @@ class ReplaceLine(LineTransformation):
 
 @attr.s(frozen=True, auto_attribs=True)
 class InsertLine(LineTransformation):
-    _schema: LineTransformationSchema
-    line: FileLine
     insertion: FileLine
 
     @property


### PR DESCRIPTION
Prior to this change the 'delete-line', 'replace-line', and 'insert-line' options for line-replacement were unusable because of the abstract line property.