### PR TITLE
reimplementation of heldout-test evaluation structure 

### DIFF
--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -18,7 +18,7 @@ import random
 from loguru import logger
 
 from . import exceptions as exc
-from .candidate import Candidate
+from .candidate import (Candidate, DiffCandidate)
 from .container import ProgramContainer
 from .outcome import (BuildOutcome, CandidateOutcome, CandidateOutcomeStore,
                       TestOutcome, TestOutcomeSet)
@@ -36,7 +36,7 @@ from .util import Stopwatch
 if typing.TYPE_CHECKING:
     from .problem import Problem
 
-Evaluation = Tuple[Candidate, CandidateOutcome]
+Evaluation = Tuple[Union[ Candidate, DiffCandidate ], CandidateOutcome]
 
 
 class Evaluator(DarjeelingEventProducer):
@@ -137,7 +137,7 @@ class Evaluator(DarjeelingEventProducer):
 
     def _run_test(self,
                   container: ProgramContainer,
-                  candidate: Candidate,
+                  candidate: Union[ Candidate, DiffCandidate ],
                   test: Test
                   ) -> TestOutcome:
         """Runs a test for a given patch using a provided container."""
@@ -168,7 +168,7 @@ class Evaluator(DarjeelingEventProducer):
         self.dispatch(TestExecutionFinished(candidate, test, outcome))
         return outcome
 
-    def _evaluate(self, candidate: Candidate) -> CandidateOutcome:
+    def _evaluate(self, candidate: Union[ Candidate, DiffCandidate ]) -> CandidateOutcome:
         outcomes = self.__outcomes
         patch = candidate.to_diff()
         logger.info(f"evaluating candidate: {candidate}\n{patch}\n")
@@ -267,7 +267,7 @@ class Evaluator(DarjeelingEventProducer):
         finally:
             logger.info(f"evaluated candidate: {candidate}")
 
-    def evaluate(self, candidate: Candidate) -> Evaluation:
+    def evaluate(self, candidate: Union[ Candidate, DiffCandidate ]) -> Evaluation:
         """Evaluates a given candidate patch."""
         outcomes = self.__outcomes
         self.dispatch(CandidateEvaluationStarted(candidate))
@@ -288,7 +288,7 @@ class Evaluator(DarjeelingEventProducer):
             self.__num_running -= 1
         return (candidate, outcome)
 
-    def submit(self, candidate: Candidate) -> 'Future[Evaluation]':
+    def submit(self, candidate: Union[ Candidate, DiffCandidate ]) -> 'Future[Evaluation]':
         """Schedules a candidate patch evaluation."""
         with self.__lock:
             self.__num_running += 1

--- a/src/darjeeling/problem.py
+++ b/src/darjeeling/problem.py
@@ -14,6 +14,7 @@ from .core import Test, FileLine, FileLineSet
 from .source import ProgramSource, ProgramSourceLoader
 from .exceptions import NoFailingTests, NoImplicatedLines
 
+
 if typing.TYPE_CHECKING:
     from .config import Config, OptimizationsConfig
     from .core import Language, TestCoverageMap
@@ -145,6 +146,51 @@ class Problem:
         problem.validate()
         return problem
 
+    @staticmethod
+    def build_evaluation(environment: 'Environment',
+              config: 'EvaluateConfig',
+              language: 'Language',
+              program: 'ProgramDescription',
+              *,
+              patch_files: set,
+              ) -> 'Problem':
+        """Constructs a Problem description based on Patch file for evaluation only.
+
+        Raises
+        -------
+        """
+
+        passing_tests: Sequence[Test] = \
+            tuple( sorted(program.tests) )
+        
+        failing_tests: Sequence[Test] = tuple()
+
+        logger.info("ordering test cases")
+        test_ordering: Sequence[Test] = \
+            tuple(sorted(program.tests))
+        logger.info('test order: {}', ', '.join(t.name for t in test_ordering))
+
+        logger.debug("storing contents of source code files")
+        source_files = set(patch_files)
+        source_loader = ProgramSourceLoader(environment)
+        sources = source_loader.for_program(program, files=source_files)
+        logger.debug("stored contents of source code files")
+
+        solution = Problem(environment=environment,
+                          program=program,
+                          language=language,
+                          sources=sources,
+                          config=config,
+                          passing_tests=passing_tests,
+                          failing_tests=failing_tests,
+                          test_ordering=test_ordering,
+                          analysis=None,
+                          coverage=None,
+                          localization=None
+                          )
+        
+        return solution
+
     def validate(self) -> None:
         """
         Ensures that this repair problem is valid. To be considered valid, a
@@ -188,3 +234,4 @@ class Problem:
     @property
     def implicated_files(self) -> Iterator[str]:
         yield from set(location.filename for location in self.coverage.failing.locations)
+

--- a/src/darjeeling/program.py
+++ b/src/darjeeling/program.py
@@ -35,7 +35,8 @@ class ProgramDescriptionConfig:
 
     @staticmethod
     def from_dict(dict_: Mapping[str, Any],
-                  dir_: Optional[str] = None
+                  dir_: Optional[str] = None,
+                  heldout : Optional[bool] = False
                   ) -> 'ProgramDescriptionConfig':
         def err(message: str) -> NoReturn:
             raise exc.BadConfigurationException(message)
@@ -81,11 +82,15 @@ class ProgramDescriptionConfig:
             err(f"unsupported language [{dict_['language']}]. {supported}")
 
         # test suite
-        if 'tests' not in dict_:
-            err("'tests' section is missing from 'program' section")
-        if not isinstance(dict_['tests'], dict):
-            err("'tests' section should be an object")
-        tests = TestSuiteConfig.from_dict(dict_.get('tests', {}), dir_)
+        # populate with 'heldout-tests' content only when specified 
+        # 'tests' is default behavior
+        tests_key = 'tests' if not heldout else 'heldout-tests'
+
+        if tests_key not in dict_:
+            err(f"'{tests_key} section is missing from 'program' section")
+        if not isinstance(dict_[tests_key], dict):
+            err(f"'{tests_key}' section should be an object")
+        tests = TestSuiteConfig.from_dict(dict_.get(tests_key, {}), dir_)
 
         # build instructions
         if 'build-instructions' not in dict_:

--- a/src/darjeeling/resources.py
+++ b/src/darjeeling/resources.py
@@ -37,6 +37,11 @@ class ResourceUsageTracker:
         """Constructs a new tracker with given resource limits."""
         return ResourceUsageTracker(limits=limits)
 
+    @staticmethod
+    def no_limits() -> 'ResourceUsageTracker':
+        """Constructs a new tracker with given resource limits."""
+        return ResourceUsageTracker(limits=None)
+
     def check_limits(self) -> None:
         """Checks whether the resource limit has been reached, and if so,
         throws an exception.
@@ -46,7 +51,8 @@ class ResourceUsageTracker:
         ResourceLimitReached
             If a resource limit has been reached.
         """
-        self.limits.check(self)
+        if self.limits:
+            self.limits.check(self)
 
 
 class ResourceLimit(abc.ABC):

--- a/src/darjeeling/searcher/__init__.py
+++ b/src/darjeeling/searcher/__init__.py
@@ -3,3 +3,4 @@ from .config import SearcherConfig
 from .base import Searcher
 from .exhaustive import ExhaustiveSearcher
 from .genetic import GeneticSearcher
+from .reviewer import Reviewer

--- a/src/darjeeling/searcher/reviewer.py
+++ b/src/darjeeling/searcher/reviewer.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+__all__ = ('Reviewer',)
+
+from typing import Any, Dict, Iterable, Iterator, Optional
+import typing
+from typing import List
+
+from loguru import logger
+
+from .base import Searcher
+from .config import SearcherConfig
+from ..candidate import DiffCandidate
+from ..resources import ResourceUsageTracker
+from ..transformation import Transformation
+from ..exceptions import SearchExhausted
+from bugzoo.core.patch import Patch
+
+if typing.TYPE_CHECKING:
+    from ..problem import Problem
+    from ..transformations import ProgramTransformations
+
+
+class ReviewerConfig(SearcherConfig):
+    """A configuration for reviewing patches."""
+    NAME = 'reviewer'
+
+    def __repr__(self) -> str:
+        return 'ReviewerConfig()'
+
+    def __str__(self) -> str:
+        return repr(self)
+
+    @classmethod
+    def from_dict(cls,
+                  d: Dict[str, Any],
+                  dir_: Optional[str] = None
+                  ) -> 'SearcherConfig':
+        return ReviewerConfig()
+
+    def build(self,
+              problem: 'Problem',
+              resources: ResourceUsageTracker,
+              candidates: List[Patch],
+              *,
+              threads: int = 1
+              ) -> Searcher:
+        return Reviewer(problem=problem,
+                                  resources=resources,
+                                  candidates=candidates,
+                                  threads=threads)
+
+
+class Reviewer(Searcher):
+    def __init__(self,
+                 problem: 'Problem',
+                 resources: ResourceUsageTracker,
+                 candidates: List[Patch],
+                 *,
+                 threads: int = 1
+                 ) -> None:
+        # FIXME for now!
+        self.__candidates = self.all_candidates(problem=problem, candidates=candidates)
+        super().__init__(problem=problem,
+                         resources=resources,
+                         threads=threads,
+                         run_redundant_tests=False)
+
+    @staticmethod
+    def all_candidates(problem: 'Problem',
+                       candidates: Iterable[DiffCandidate]
+                       ) -> Iterator[DiffCandidate]:
+        logger.debug(f"Obtaining all patch candidates")
+        for c in candidates:
+            logger.trace(f"Processing {repr(c)}")
+            print(f"Processing {repr(c)}")
+            yield DiffCandidate(problem,c)
+        logger.debug(f"Obtained all patch candidates")
+
+    def _generate(self) -> DiffCandidate:
+        try:
+            logger.debug('generating candidate patch...')
+            candidate = next(self.__candidates)
+            logger.debug(f'generated candidate patch: {candidate}')
+            return candidate
+        except StopIteration:
+            logger.debug('exhausted all candidate patches')
+            raise SearchExhausted
+
+    def run(self) -> Iterator[DiffCandidate]:
+        for _ in range(self.num_workers):
+            candidate = self._generate()
+            self.evaluate(candidate)
+
+        for candidate, outcome in self.as_evaluated():
+            if outcome.is_repair:
+                yield candidate
+            self.evaluate(self._generate())


### PR DESCRIPTION
based on @ChrisTimperley 's feedback issue #300 

- Enables a new CLI interface (`darjeeling evaluate`)
- tested, but seeing some issues with test timeouts (Currently, `ResourceUsageTracker(limits=None)`, so I may need to add back in this from the configuration)