### PR TITLE
Add a Dockerfile to run Darjeeling in a Dockerized environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 *
+!Pipfile
+!Pipfile.lock
 !src
 !setup.py
 !test

--- a/Dockerfile.host
+++ b/Dockerfile.host
@@ -1,0 +1,50 @@
+# This Dockerfile allows running Darjeeling itself in a Docker
+# container with a bind-mounted Docker socket.
+
+# For example, to build a Dockerized Darjeeling and run it on the
+# example/gcd project:
+
+# docker build . -f Dockerfile.host -t darjeeling_host
+# docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/example/gcd:/gcd darjeeling_host darjeeling repair /gcd/repair.yml
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Install libraries pyenv will need for Python 3.9.
+RUN apt update -eany && apt install -y \
+    python3 python3-pip \
+    git \
+    libssl-dev libffi-dev libncurses-dev \
+    libbz2-dev liblzma-dev \
+    libreadline-dev libsqlite3-dev \
+    ca-certificates curl \
+    make build-essential autoconf libtool \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Docker apt repository per official docs
+# (https://docs.docker.com/engine/install/ubuntu/) so we can install
+# just the client, not the full Docker engine.
+
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc
+# Add the repository to Apt sources:
+RUN echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$UBUNTU_CODENAME") stable" \
+    > /etc/apt/sources.list.d/docker.list
+RUN apt update && apt install -y docker-ce-cli && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone --depth=1 https://github.com/pyenv/pyenv.git pyenv
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+RUN pyenv install 3.9 && pyenv global 3.9 && python3 --version
+RUN python3 -m pip install --upgrade pip setuptools
+RUN python3 -m pip install pipenv
+
+COPY . /opt/darjeeling
+WORKDIR /opt/darjeeling
+RUN ls && env PIPENV_VENV_IN_PROJECT=1 python3 -m pipenv install --deploy
+ENV PATH="/opt/darjeeling/.venv/bin:$PATH"
+WORKDIR /


### PR DESCRIPTION
This allows running Darjeeling itself in a Docker container with a bind-mounted Docker socket it can use to start new Docker containers.